### PR TITLE
Add support for the same variable multiple times in output name

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const postcss = require('postcss');
 const csswring = require('csswring');
 
 module.exports = postcss.plugin('postcss-extract-media-query', opts => {
+
     opts = _.merge({
         entry: null,
         output: {
@@ -66,8 +67,8 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             // or otherwise the query key (converted to kebab case)
             const hasCustomName = typeof opts.queries[atRule.params] === 'string';
             const key = hasCustomName === true
-                ? opts.queries[atRule.params]
-                : _.kebabCase(atRule.params);
+                    ? opts.queries[atRule.params]
+                    : _.kebabCase(atRule.params);
 
             // extract media atRule and concatenate with existing atRule (same key)
             // if no whitelist set or if whitelist and atRule has custom query name match

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const postcss = require('postcss');
 const csswring = require('csswring');
 
 module.exports = postcss.plugin('postcss-extract-media-query', opts => {
-    
+
     opts = _.merge({
         entry: null,
         output: {
@@ -67,8 +67,8 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             // or otherwise the query key (converted to kebab case)
             const hasCustomName = typeof opts.queries[atRule.params] === 'string';
             const key = hasCustomName === true
-                        ? opts.queries[atRule.params] 
-                        : _.kebabCase(atRule.params);
+                ? opts.queries[atRule.params]
+                : _.kebabCase(atRule.params);
 
             // extract media atRule and concatenate with existing atRule (same key)
             // if no whitelist set or if whitelist and atRule has custom query name match
@@ -83,12 +83,12 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             if (opts.output.path) {
 
                 const newFile = opts.output.name
-                                .replace('[name]', name)
-                                .replace('[query]', key)
-                                .replace('[ext]', ext);
+                    .replace(/\[name\]/g, name)
+                    .replace(/\[query\]/g, key)
+                    .replace(/\[ext\]/g, ext)
 
                 const newFilePath = path.join(opts.output.path, newFile);
-                
+
                 // create new root
                 // and append all extracted atRules with current key
                 const newRoot = postcss.root();
@@ -97,9 +97,9 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
                 });
 
                 if (opts.minimize === true) {
-                    const newRootMinimized = postcss([ csswring() ])
-                                                .process(newRoot.toString(), { from: newFilePath })
-                                                .root;
+                    const newRootMinimized = postcss([csswring()])
+                        .process(newRoot.toString(), { from: newFilePath })
+                        .root;
                     fs.outputFileSync(newFilePath, newRootMinimized.toString());
                 } else {
                     fs.outputFileSync(newFilePath, newRoot.toString());

--- a/index.js
+++ b/index.js
@@ -82,9 +82,9 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             if (opts.output.path) {
 
                 const newFile = opts.output.name
-                        .replace(/\[name\]/g, name)
-                        .replace(/\[query\]/g, key)
-                        .replace(/\[ext\]/g, ext)
+                                .replace(/\[name\]/g, name)
+                                .replace(/\[query\]/g, key)
+                                .replace(/\[ext\]/g, ext)
 
                 const newFilePath = path.join(opts.output.path, newFile);
 
@@ -97,8 +97,8 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
 
                 if (opts.minimize === true) {
                     const newRootMinimized = postcss([ csswring() ])
-                                .process(newRoot.toString(), { from: newFilePath })
-                                .root;
+                                                .process(newRoot.toString(), { from: newFilePath })
+                                                .root;
                     fs.outputFileSync(newFilePath, newRootMinimized.toString());
                 } else {
                     fs.outputFileSync(newFilePath, newRoot.toString());

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const postcss = require('postcss');
 const csswring = require('csswring');
 
 module.exports = postcss.plugin('postcss-extract-media-query', opts => {
-
     opts = _.merge({
         entry: null,
         output: {
@@ -67,8 +66,8 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             // or otherwise the query key (converted to kebab case)
             const hasCustomName = typeof opts.queries[atRule.params] === 'string';
             const key = hasCustomName === true
-                    ? opts.queries[atRule.params]
-                    : _.kebabCase(atRule.params);
+                        ? opts.queries[atRule.params]
+                        : _.kebabCase(atRule.params);
 
             // extract media atRule and concatenate with existing atRule (same key)
             // if no whitelist set or if whitelist and atRule has custom query name match
@@ -83,9 +82,9 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             if (opts.output.path) {
 
                 const newFile = opts.output.name
-                    .replace(/\[name\]/g, name)
-                    .replace(/\[query\]/g, key)
-                    .replace(/\[ext\]/g, ext)
+                        .replace(/\[name\]/g, name)
+                        .replace(/\[query\]/g, key)
+                        .replace(/\[ext\]/g, ext)
 
                 const newFilePath = path.join(opts.output.path, newFile);
 
@@ -98,8 +97,8 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
 
                 if (opts.minimize === true) {
                     const newRootMinimized = postcss([ csswring() ])
-                        .process(newRoot.toString(), { from: newFilePath })
-                        .root;
+                                .process(newRoot.toString(), { from: newFilePath })
+                                .root;
                     fs.outputFileSync(newFilePath, newRootMinimized.toString());
                 } else {
                     fs.outputFileSync(newFilePath, newRoot.toString());

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const postcss = require('postcss');
 const csswring = require('csswring');
 
 module.exports = postcss.plugin('postcss-extract-media-query', opts => {
+    
     opts = _.merge({
         entry: null,
         output: {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const postcss = require('postcss');
 const csswring = require('csswring');
 
 module.exports = postcss.plugin('postcss-extract-media-query', opts => {
-
     opts = _.merge({
         entry: null,
         output: {
@@ -97,7 +96,7 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
                 });
 
                 if (opts.minimize === true) {
-                    const newRootMinimized = postcss([csswring()])
+                    const newRootMinimized = postcss([ csswring() ])
                         .process(newRoot.toString(), { from: newFilePath })
                         .root;
                     fs.outputFileSync(newFilePath, newRootMinimized.toString());

--- a/test/options.js
+++ b/test/options.js
@@ -68,6 +68,7 @@ describe('Options', function() {
             assert.isTrue(fs.existsSync('test/output/example-screen-and-min-width-1024-px.css'));
             assert.isTrue(fs.existsSync('test/output/example-screen-and-min-width-1200-px.css'));
         });
+
         it('output.name should affect emited filenames', function() {
             const opts = {
                 output: {
@@ -79,6 +80,19 @@ describe('Options', function() {
             postcss([ plugin(opts) ]).process(exampleFile, { from: 'test/data/example.css'}).css;
             assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1024-px.css'));
             assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1200-px.css'));
+        });
+
+        it('output.name can have the same variable multiple times', function () {
+            const opts = {
+                output: {
+                    path: path.join(__dirname, 'output'),
+                    name: '[query]-[query].[ext]'
+                },
+                stats: false
+            };
+            postcss([plugin(opts)]).process(exampleFile, { from: 'test/data/example.css' }).css;
+            assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1024-px-screen-and-min-width-1024-px.css'));
+            assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1200-px-screen-and-min-width-1200-px.css'));
         });
     });
 

--- a/test/options.js
+++ b/test/options.js
@@ -68,7 +68,6 @@ describe('Options', function() {
             assert.isTrue(fs.existsSync('test/output/example-screen-and-min-width-1024-px.css'));
             assert.isTrue(fs.existsSync('test/output/example-screen-and-min-width-1200-px.css'));
         });
-
         it('output.name should affect emited filenames', function() {
             const opts = {
                 output: {
@@ -81,8 +80,7 @@ describe('Options', function() {
             assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1024-px.css'));
             assert.isTrue(fs.existsSync('test/output/screen-and-min-width-1200-px.css'));
         });
-
-        it('output.name can have the same variable multiple times', function () {
+        it('output.name should support using the same placeholder multiple times', function () {
             const opts = {
                 output: {
                     path: path.join(__dirname, 'output'),


### PR DESCRIPTION
Hi I've added support to for multiple placeholder replacements of the same variable name. So you can do stuff like 
```js
output: {
            path: path.join(__dirname, '..'),
            name: '[query]/[name]-[query].[ext]'
        },
```