### PR TITLE
fix file regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ module.exports = postcss.plugin('postcss-extract-media-query', opts => {
             from = result.opts.from;
         }
 
-        const file = from.match(/[^/\\]+\.\w+$/)[0].split('.');
-        const name = file[0];
-        const ext = file[1];
+        const file = from.match(/([^/\\]+)\.(\w+)(?:\?.+)?$/);
+        const name = file[1];
+        const ext = file[2];
 
         const newAtRules = {};
 

--- a/test/data/entry-example.namespace.css
+++ b/test/data/entry-example.namespace.css
@@ -1,0 +1,3 @@
+@media screen {
+  .foo { color: blue; }
+}

--- a/test/options.js
+++ b/test/options.js
@@ -36,14 +36,14 @@ describe('Options', function() {
     describe('entry', function() {
         it('entry should override any other from option', function() {
             const opts = {
-                entry: path.join(__dirname, 'data/entry-example.css'),
+                entry: path.join(__dirname, 'data/entry-example.namespace.css'),
                 output: {
                     path: path.join(__dirname, 'output')
                 },
                 stats: false
             };
             postcss([ plugin(opts) ]).process(entryExampleFile, { from: 'test/data/example.css'}).css;
-            assert.isTrue(fs.existsSync('test/output/entry-example-screen.css'));
+            assert.isTrue(fs.existsSync('test/output/entry-example.namespace-screen.css'));
         });
     });
 


### PR DESCRIPTION
Fixes #8 

This lets you use dot separated namespace in your file names, such as `example.namespace.css`
