### PR TITLE
Rework extraction to support nested atRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ By default the params of the extracted media query is converted to kebab case an
 }
 ```
 
-### whitelist
+### extractAll
 
-By default the plugin extracts all media queries into separate files. If you want it to only extract the ones you've defined a certain name for (see `queries` option) you have to set this option `true`. This ignores all media queries that don't have a custom name defined.
+By default the plugin extracts all media queries into separate files. If you want it to only extract the ones you've defined a certain name for (see `queries` option) you have to set this option `false`. This ignores all media queries that don't have a custom name defined.
 
 ```javascript
 'postcss-extract-media-query': {
-    whitelist: true
+    extractAll: false
 }
 ```
 

--- a/combine-media.js
+++ b/combine-media.js
@@ -1,0 +1,34 @@
+/**
+ * TODO: move this into own repo for more use cases
+ */
+
+const postcss = require('postcss');
+
+module.exports = postcss.plugin('postcss-combine-media-query', opts => {
+
+    const atRules = {};
+
+    function addToAtRules(atRule) {
+        const key = atRule.params;
+
+        if (!atRules[key]) {
+            atRules[key] = postcss.atRule({ name: atRule.name, params: atRule.params });
+        }
+        atRule.nodes.forEach(node => {
+            atRules[key].append(node.clone());
+        });
+
+        atRule.remove();
+    }
+    
+    return (root) => {
+
+        root.walkAtRules('media', atRule => {
+            addToAtRules(atRule);
+        });
+
+        Object.keys(atRules).forEach(key => {
+            root.append(atRules[key]);
+        });
+    };
+});

--- a/test/options.js
+++ b/test/options.js
@@ -14,21 +14,21 @@ describe('Options', function() {
         fs.removeSync('test/output');
     });
 
-    describe('whitelist', function() {
+    describe('extractAll', function() {
         it('true should cause to ignore all media queries except of the ones defined in the queries options', function() {
             const opts = {
                 output: {
                     path: path.join(__dirname, 'output')
                 },
                 queries: {
-                    'screen and (min-width: 999px)': 'whitelist'
+                    'screen and (min-width: 999px)': 'extract-all'
                 },
-                whitelist: true,
+                extractAll: false,
                 stats: false
             };
             postcss([ plugin(opts) ]).process(exampleFile, { from: 'test/data/example.css'}).css;
             const filesCount = fs.readdirSync('test/output/').length;
-            assert.isTrue(fs.existsSync('test/output/example-whitelist.css'));
+            assert.isTrue(fs.existsSync('test/output/example-extract-all.css'));
             assert.equal(filesCount, 1);
         });
     });


### PR DESCRIPTION
Closes #2 

This also introduces a new option called `extractAll` that replaces `whitelist`.
However I've avoided a breaking change (`whitelist` can still be used) so I can deploy it in v1.x