### PR TITLE
feat(config): add output.useSourceDir option to emit extracted files alongside source CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,23 @@ You can find complete examples <a href="examples">here</a>.
 
 ## Options
 
-| option      | default                      |
-| ----------- | ---------------------------- |
-| output.path | path.join(\_\_dirname, '..') |
-| output.name | '[name]-[query].[ext]'       |
-| queries     | {}                           |
-| extractAll  | true                         |
-| stats       | true                         |
-| entry       | null                         |
+| option              | default                      |
+| ------------------- | ---------------------------- |
+| output.path         | path.join(\_\_dirname, '..') |
+| output.name         | '[name]-[query].[ext]'       |
+| output.useSourceDir | false                        |
+| queries             | {}                           |
+| extractAll          | true                         |
+| stats               | true                         |
+| entry               | null                         |
 
 ### output
 
 By default the plugin will emit the extracted CSS files to your root folder. If you want to change this you have to define an **absolute** path for `output.path`.
 
-Apart from that you can customize the emited filenames by using `output.name`. `[name]` is the filename of the original CSS file, `[query]` the key of the extracted media query and `[ext]` the orignal file extension (mostly `css`). Those three placeholders get replaced by the plugin later.
+Apart from that you can customize the emitted filenames by using `output.name`. `[name]` is the filename of the original CSS file, `[query]` the key of the extracted media query and `[ext]` the original file extension (mostly `css`). Those three placeholders get replaced by the plugin later.
 
-> :warning: by emiting files itself the plugin breaks out of your bundler / task runner context meaning all your other loaders / pipes won't get applied to the extracted files!
+> :warning: by emitting files itself the plugin breaks out of your bundler / task runner context meaning all your other loaders / pipes won't get applied to the extracted files!
 
 ```javascript
 'postcss-extract-media-query': {
@@ -104,6 +105,19 @@ Apart from that you can customize the emited filenames by using `output.name`. `
     }
 }
 ```
+output.useSourceDir
+If set to true, the plugin will emit the extracted CSS files in the same directory as the source CSS file instead of using output.path.
+
+This is useful when you want the media-specific files to be generated alongside their respective source files—particularly helpful in monorepos or multi-entry setups.
+
+```javascript
+'postcss-extract-media-query': {
+    output: {
+        useSourceDir: true
+    }
+}
+```
+If both `output.useSourceDir` and `output.path` are provided, **useSourceDir**: true takes precedence.
 
 ### queries
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = (opts) => {
       output: {
         path: path.join(__dirname, '..'),
         name: '[name]-[query].[ext]',
+        useSourceDir: false,
       },
       queries: {},
       extractAll: true,
@@ -56,6 +57,7 @@ module.exports = (opts) => {
       const file = from.match(/([^/\\]+)\.(\w+)(?:\?.+)?$/);
       const name = file[1];
       const ext = file[2];
+      const entryPath =  path.dirname(from);
 
       if (opts.output.path) {
         root.walkAtRules('media', (atRule) => {
@@ -85,7 +87,9 @@ module.exports = (opts) => {
                 .replace(/\[name\]/g, name)
                 .replace(/\[query\]/g, queryname)
                 .replace(/\[ext\]/g, ext);
-              const newFilePath = path.join(opts.output.path, newFile);
+
+              const newPath = opts.output.useSourceDir ? entryPath : opts.output.path;
+              const newFilePath = path.join(newPath, newFile);
               const newFileDir = path.dirname(newFilePath);
 
               plugins.applyPlugins(css, newFilePath).then((css) => {

--- a/test/options.js
+++ b/test/options.js
@@ -142,6 +142,79 @@ describe('Options', function () {
     });
   });
 
+  describe('output.useSourceDir', function () {
+
+    beforeEach((done) => {
+      // Eliminar cualquier archivo generado por estos tests en el mismo directorio fuente
+      fs.readdirSync(path.join(__dirname, 'data')).forEach((file) => {
+        if (
+          file.startsWith('example-') &&
+          file.endsWith('.css') &&
+          file !== 'example.css'
+        ) {
+          fs.unlinkSync(path.join(__dirname, 'data', file));
+        }
+      });
+      done();
+    });
+
+    it('should emit extracted files in the same directory as the source file when useSourceDir is true', (done) => {
+      const opts = {
+        output: {
+          useSourceDir: true,
+        },
+        stats: false,
+      };
+
+      postcss([plugin(opts)])
+        .process(exampleFile, { from: 'test/data/example.css' })
+        .then(() => {
+          const expected = path.join(__dirname, 'data/example-screen-and-min-width-1024-px.css');
+          assert.isTrue(fs.existsSync(expected));
+          done();
+        });
+    });
+
+    it('should ignore output.path when useSourceDir is true', (done) => {
+      const opts = {
+        output: {
+          path: path.join(__dirname, 'output'),
+          useSourceDir: true,
+        },
+        stats: false,
+      };
+
+      postcss([plugin(opts)])
+        .process(exampleFile, { from: 'test/data/example.css' })
+        .then(() => {
+          const sourceOutput = path.join(__dirname, 'data/example-screen-and-min-width-1024-px.css');
+          const outputPath = path.join(__dirname, 'output/example-screen-and-min-width-1024-px.css');
+
+          assert.isTrue(fs.existsSync(sourceOutput));
+          assert.isFalse(fs.existsSync(outputPath));
+          done();
+        });
+    });
+
+    it('should emit to output.path if useSourceDir is false', (done) => {
+      const opts = {
+        output: {
+          path: path.join(__dirname, 'output'),
+          useSourceDir: false,
+        },
+        stats: false,
+      };
+
+      postcss([plugin(opts)])
+        .process(exampleFile, { from: 'test/data/example.css' })
+        .then(() => {
+          const expected = path.join(__dirname, 'output/example-screen-and-min-width-1024-px.css');
+          assert.isTrue(fs.existsSync(expected));
+          done();
+        });
+    });
+  });
+
   describe('queries', function () {
     it('should use specified query that exactly matches', (done) => {
       const opts = {


### PR DESCRIPTION
### Summary

This PR introduces a new `output.useSourceDir` option to the `postcss-extract-media-query` plugin.

When set to `true`, the plugin will emit extracted media query files to the same directory as the source CSS file, instead of using the `output.path` setting. This can be particularly helpful in monorepos or modular CSS architectures where keeping related files together is beneficial.

### Fix
Fixes #48 

### Changes

- Added `output.useSourceDir` boolean option.
- Updated core logic to resolve output path based on source file if the new flag is enabled.
- Included test coverage to validate behavior.
- Updated README with full documentation and usage example.

### Motivation

This feature enables more flexible and intuitive file management in projects with distributed or multi-package structures. It avoids manual configuration of absolute output paths when extracted files should stay near their corresponding sources.

### Backward Compatibility

This change is fully backward-compatible. If `output.useSourceDir` is not set or is `false`, the plugin behaves as before.
